### PR TITLE
ci: try for auto changelog ...3

### DIFF
--- a/.github/workflows/squash_and_merge_changelog.yaml
+++ b/.github/workflows/squash_and_merge_changelog.yaml
@@ -22,6 +22,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install commitizen bumpversion
+          which -a cz
+          which -a bumpversion
       - name: Check if PR merge
         id: check_pr_merge
         run: |
@@ -68,7 +70,7 @@ jobs:
         if: steps.check_pr_merge.outputs.is_pr_merge == 'true'
         run: |
           # Generate changelog
-          commitizen changelog --changelog-path ./CHANGELOG.md
+          cz changelog --changelog-path ./CHANGELOG.md
 
           # Stage changes
           git add ./CHANGELOG.md


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflow to debug changelog generation process

CI:
- Add diagnostic commands to check commitizen and bumpversion installations
- Modify changelog generation command from 'commitizen' to 'cz'